### PR TITLE
PLATOPS-1850: Convert artefact names to lowercase in Artifactory paths

### DIFF
--- a/src/main/scala/uk/gov/hmrc/ArtifactDescription.scala
+++ b/src/main/scala/uk/gov/hmrc/ArtifactDescription.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018 HM Revenue & Customs
+ * Copyright 2019 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/scala/uk/gov/hmrc/ArtifactDescription.scala
+++ b/src/main/scala/uk/gov/hmrc/ArtifactDescription.scala
@@ -73,7 +73,7 @@ case class MavenArtifactDescription(
 
   override lazy val toString: String = s"$org:$name:scala_$scalaVersion:$version"
 
-  override lazy val path: String = s"${dotsToSlashes(org)}/${name}_$scalaVersion/$version"
+  override lazy val path: String = s"${dotsToSlashes(org)}/${name.toLowerCase()}_$scalaVersion/$version"
 
   private def dotsToSlashes(expression: String): String = expression.replaceAll("""\.""", "/")
 }
@@ -99,6 +99,6 @@ case class IvySbtArtifactDescription(
         throw new Exception(s"Unable to extract Sbt version from $sbtVersion")
       }
 
-  override lazy val path: String = s"$org/$name/scala_$scalaVersion/sbt_$sbtVersionFragment/$version"
+  override lazy val path: String = s"$org/${name.toLowerCase()}/scala_$scalaVersion/sbt_$sbtVersionFragment/$version"
 
 }

--- a/src/main/scala/uk/gov/hmrc/ArtifactoryConnector.scala
+++ b/src/main/scala/uk/gov/hmrc/ArtifactoryConnector.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018 HM Revenue & Customs
+ * Copyright 2019 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/scala/uk/gov/hmrc/BintrayDistributor.scala
+++ b/src/main/scala/uk/gov/hmrc/BintrayDistributor.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018 HM Revenue & Customs
+ * Copyright 2019 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/scala/uk/gov/hmrc/SbtArtifactory.scala
+++ b/src/main/scala/uk/gov/hmrc/SbtArtifactory.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018 HM Revenue & Customs
+ * Copyright 2019 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/scala/uk/gov/hmrc/ArtifactDescriptionSpec.scala
+++ b/src/test/scala/uk/gov/hmrc/ArtifactDescriptionSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018 HM Revenue & Customs
+ * Copyright 2019 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/scala/uk/gov/hmrc/ArtifactDescriptionSpec.scala
+++ b/src/test/scala/uk/gov/hmrc/ArtifactDescriptionSpec.scala
@@ -47,7 +47,7 @@ class ArtifactDescriptionSpec extends WordSpec {
         )
     }
 
-    "create a SbtPluginArtifactDescription if it's a plugin" in {
+    "create an IvySbtArtifactDescription if it's a plugin" in {
       ArtifactDescription
         .withCrossScalaVersion(
           org            = "org.domain",
@@ -82,6 +82,10 @@ class ArtifactDescriptionSpec extends WordSpec {
     "be formed using pattern: 'org/name_scalaVersion/version' - case when artifact-name contains dots" in {
       MavenArtifactDescription("uk.gov.hmrc", "my-artifact.public", "0.1.0", "2.11", Random.nextBoolean()).path shouldBe "uk/gov/hmrc/my-artifact.public_2.11/0.1.0"
     }
+
+    "should convert the name of the artifact to lowercase" in {
+      MavenArtifactDescription("org", "My-Artifact", "0.1.0", "2.11", Random.nextBoolean()).path shouldBe "org/my-artifact_2.11/0.1.0"
+    }
   }
 
   "MavenArtifactDescription.toString" should {
@@ -102,6 +106,10 @@ class ArtifactDescriptionSpec extends WordSpec {
 
     "be formed using pattern: 'org/name_scalaVersion/version' - case when artifact-name contains dots" in {
       IvySbtArtifactDescription("uk.gov.hmrc", "my-artifact.public", "0.1.0", "2.11", "0.13.17", Random.nextBoolean()).path shouldBe "uk.gov.hmrc/my-artifact.public/scala_2.11/sbt_0.13/0.1.0"
+    }
+
+    "should convert the name of the artifact to lowercase" in {
+      IvySbtArtifactDescription("org", "My-Artifact", "0.1.0", "2.11", "0.13.17", Random.nextBoolean()).path shouldBe "org/my-artifact/scala_2.11/sbt_0.13/0.1.0"
     }
   }
 

--- a/src/test/scala/uk/gov/hmrc/ArtifactoryConnectorSpec.scala
+++ b/src/test/scala/uk/gov/hmrc/ArtifactoryConnectorSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018 HM Revenue & Customs
+ * Copyright 2019 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/scala/uk/gov/hmrc/BintrayDistributorSpec.scala
+++ b/src/test/scala/uk/gov/hmrc/BintrayDistributorSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018 HM Revenue & Customs
+ * Copyright 2019 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/scala/uk/gov/hmrc/SbtArtifactorySpec.scala
+++ b/src/test/scala/uk/gov/hmrc/SbtArtifactorySpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018 HM Revenue & Customs
+ * Copyright 2019 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.


### PR DESCRIPTION
Artifactory converts artefact names to lowercase and this PR fixes the following issues with public libraries containing uppercase letters in its name:
- distributing a public library would fail due to Artifactory converting artefact names to lowercase.
- unpublishing a public library would fail since the Artifactory REST API is case-sensitive. 