### PR TITLE
BDOG-794: sbt-artifactory is now a triggered plugin

### DIFF
--- a/src/main/scala-sbt-1.0/uk/gov/hmrc/DispatchCrossSupport.scala
+++ b/src/main/scala-sbt-1.0/uk/gov/hmrc/DispatchCrossSupport.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 HM Revenue & Customs
+ * Copyright 2020 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/scala/uk/gov/hmrc/ArtifactDescription.scala
+++ b/src/main/scala/uk/gov/hmrc/ArtifactDescription.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 HM Revenue & Customs
+ * Copyright 2020 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/scala/uk/gov/hmrc/ArtifactoryConnector.scala
+++ b/src/main/scala/uk/gov/hmrc/ArtifactoryConnector.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 HM Revenue & Customs
+ * Copyright 2020 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/scala/uk/gov/hmrc/BintrayConnector.scala
+++ b/src/main/scala/uk/gov/hmrc/BintrayConnector.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 HM Revenue & Customs
+ * Copyright 2020 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/scala/uk/gov/hmrc/BintrayDistributor.scala
+++ b/src/main/scala/uk/gov/hmrc/BintrayDistributor.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 HM Revenue & Customs
+ * Copyright 2020 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/scala/uk/gov/hmrc/SbtArtifactory.scala
+++ b/src/main/scala/uk/gov/hmrc/SbtArtifactory.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 HM Revenue & Customs
+ * Copyright 2020 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/scala/uk/gov/hmrc/SbtArtifactory.scala
+++ b/src/main/scala/uk/gov/hmrc/SbtArtifactory.scala
@@ -126,6 +126,8 @@ object SbtArtifactory extends sbt.AutoPlugin {
       ).value
   )
 
+  override def trigger = allRequirements
+
   private[hmrc] def artifactoryRepoKey(sbtPlugin: Boolean, publicArtifact: Boolean): String =
     (sbtPlugin, publicArtifact) match {
       case (false, false) => "hmrc-releases-local"

--- a/src/test/scala/uk/gov/hmrc/ArtifactDescriptionSpec.scala
+++ b/src/test/scala/uk/gov/hmrc/ArtifactDescriptionSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 HM Revenue & Customs
+ * Copyright 2020 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/scala/uk/gov/hmrc/ArtifactoryConnectorSpec.scala
+++ b/src/test/scala/uk/gov/hmrc/ArtifactoryConnectorSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 HM Revenue & Customs
+ * Copyright 2020 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/scala/uk/gov/hmrc/BintrayDistributorSpec.scala
+++ b/src/test/scala/uk/gov/hmrc/BintrayDistributorSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 HM Revenue & Customs
+ * Copyright 2020 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/scala/uk/gov/hmrc/SbtArtifactorySpec.scala
+++ b/src/test/scala/uk/gov/hmrc/SbtArtifactorySpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 HM Revenue & Customs
+ * Copyright 2020 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.


### PR DESCRIPTION
An sbt auto-plugin is not enabled by default, see [Triggered Plugins](https://www.scala-sbt.org/1.x/docs/Plugins.html#Root+plugins+and+triggered+plugins).

If we configure sbt-dependency-graph, sbt-bobby, and sbt-artifactory as global plugins (with no explicit references in the project) we see:

```
sbt plugins  

net.virtualvoid.sbt.graph.DependencyGraphPlugin: enabled in foo-backend
uk.gov.hmrc.SbtArtifactory
uk.gov.hmrc.SbtBobbyPlugin: enabled in foo-backend
```

Note that SbtArtifactory is not enabled, in contrast with SbtBobbyPlugin.

This change makes SbtArtifactory a triggered plugin.  It will then attach to a project without requiring an explicit 'enablePlugin' statement in build.sbt