### PR TITLE
Fix dependency eviction

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -9,6 +9,17 @@ val pluginName = "sbt-artifactory"
 // The main motivation for this is a conflict between dependencies of global and local plugins.
 // On sbt 1.3.x their dependencies are merged before evicting, cause some runtime errors. This
 // seems to be resolved on sbt 1.4.x.
+val shadedPackages = Seq(
+  "bintry",
+  "bintray",
+  "com.ning",
+  "com.thoughtworks",
+  "dispatch",
+  "org.jboss",
+  "org.json4s",
+  "org.slf4j"
+)
+
 lazy val project = Project(pluginName, file("."))
   .enablePlugins(SbtAutoBuildPlugin, SbtGitVersioning, SbtArtifactory, ShadingPlugin)
   .settings(
@@ -29,6 +40,7 @@ lazy val project = Project(pluginName, file("."))
       // (TODO should they be added to libaryDependencies?)
       exclude("org.scala-lang.modules", "scala-xml_2.12")
       exclude("org.scala-lang", "*")
+
       // TODO infact we could exclude all except dispatch? - this is the one which is causing problems
     ),
     // *********************************
@@ -40,14 +52,10 @@ lazy val project = Project(pluginName, file("."))
       "com.vladsch.flexmark"  % "flexmark-all"                % "0.35.10"  % Test // replaces pegdown for newer scalatest
     ),
 
-    shadedModules += "org.foundweekends" % "sbt-bintray",
-    shadingRules += ShadingRule.moveUnder("dispatch", "uk.gov.hmrc.sbt-artifactory.shaded"),
-    shadingRules += ShadingRule.moveUnder("com",      "uk.gov.hmrc.sbt-artifactory.shaded"),
-    shadingRules += ShadingRule.moveUnder("bintry",   "uk.gov.hmrc.sbt-artifactory.shaded"),
-    shadingRules += ShadingRule.moveUnder("bintray",  "uk.gov.hmrc.sbt-artifactory.shaded"),
+    shadedModules   += "org.foundweekends" % "sbt-bintray",
+    shadingRules    ++= shadedPackages.map(ShadingRule.moveUnder(_, "uk.gov.hmrc.sbt-artifactory.shaded")),
     validNamespaces += "uk",
     validNamespaces += "sbt", // sbt/sbt.autoplugins needs to be in route
-    validNamespaces += "org", // org.scalajs.sbtplugin.ScalaJSPlugin$AutoImport$ needs to be untouched
 
     shadingVerbose := true,
   )

--- a/build.sbt
+++ b/build.sbt
@@ -50,8 +50,14 @@ lazy val project = Project(pluginName, file("."))
       "com.vladsch.flexmark"  % "flexmark-all"                % "0.35.10"  % Test // replaces pegdown for newer scalatest
     ),
 
+    // sbt_bintray pulls in dispatch-core 0.11.2, which strips out trailing `/`, breaking delete calls to Artifactory
+    dependencyOverrides ++= (sbtVersion in pluginCrossBuild) {
+      case v if v startsWith "0.13" => Seq("net.databinder.dispatch" %% "dispatch-core" % "0.11.4")
+      case v if v startsWith "1.3" => Seq.empty[ModuleID]
+    }.value,
+
     shadedModules   += "org.foundweekends" % "sbt-bintray",
     shadingRules    ++= shadedPackages.map(ShadingRule.moveUnder(_, "uk.gov.hmrc.sbt-artifactory.shaded")),
     validNamespaces += "uk", // doesn't support nested namespaces (e.g. "uk.gov.hmrc") since it matches all directories in the created jar (including parent directories)
-    validNamespaces += "sbt" // sbt/sbt.autoplugins needs to be in route
+    validNamespaces += "sbt" // sbt/sbt.autoplugins needs to be in root
   )

--- a/build.sbt
+++ b/build.sbt
@@ -5,8 +5,12 @@ import uk.gov.hmrc.versioning.SbtGitVersioning
 
 val pluginName = "sbt-artifactory"
 
+// We are shading the project's dependencies.
+// The main motivation for this is a conflict between dependencies of global and local plugins.
+// On sbt 1.3.x their dependencies are merged before evicting, cause some runtime errors. This
+// seems to be resolved on sbt 1.4.x.
 lazy val project = Project(pluginName, file("."))
-  .enablePlugins(SbtAutoBuildPlugin, SbtGitVersioning, SbtArtifactory)
+  .enablePlugins(SbtAutoBuildPlugin, SbtGitVersioning, SbtArtifactory, ShadingPlugin)
   .settings(
     majorVersion := 1,
     makePublicallyAvailableOnBintray := true
@@ -19,7 +23,14 @@ lazy val project = Project(pluginName, file("."))
     //       the build as you might expect. Code in the plugin is used in the SbtArtifactory object.
     scalaVersion := "2.12.12",
     addSbtPlugin("org.scala-js" % "sbt-scalajs" % "0.6.31"),
-    addSbtPlugin("org.foundweekends" % "sbt-bintray" % "0.5.6"),
+    addSbtPlugin("org.foundweekends" % "sbt-bintray" % "0.5.6"
+      // exclude "provided" otherwise they will be included in shaded jar
+      // scala-xml contains "scala-xml.properties" which can't be excluded with validNamespaces
+      // (TODO should they be added to libaryDependencies?)
+      exclude("org.scala-lang.modules", "scala-xml_2.12")
+      exclude("org.scala-lang", "*")
+      // TODO infact we could exclude all except dispatch? - this is the one which is causing problems
+    ),
     // *********************************
     libraryDependencies ++= Seq(
       "com.typesafe.play"     %% "play-json"                  % "2.6.14",
@@ -28,13 +39,15 @@ lazy val project = Project(pluginName, file("."))
       "org.scalatestplus"     %% "scalatestplus-mockito"      % "1.0.0-M2" % Test,
       "com.vladsch.flexmark"  % "flexmark-all"                % "0.35.10"  % Test // replaces pegdown for newer scalatest
     ),
-    // There is no release of dispatch cross-compiled for both scala 2.10 and scala 2.12 (required by sbt 0.13/1.x)
-    // As a result, use a version dependent on the sbtVersion
-    libraryDependencies ++= (sbtVersion in pluginCrossBuild) { version =>
-      val dispatchVersion = version match {
-        case v if v startsWith "0.13" => "0.11.4"
-        case v if v startsWith "1.3" => "0.12.0"
-      }
-      Seq("net.databinder.dispatch" %% "dispatch-core" % dispatchVersion)
-    }.value
+
+    shadedModules += "org.foundweekends" % "sbt-bintray",
+    shadingRules += ShadingRule.moveUnder("dispatch", "uk.gov.hmrc.sbt-artifactory.shaded"),
+    shadingRules += ShadingRule.moveUnder("com",      "uk.gov.hmrc.sbt-artifactory.shaded"),
+    shadingRules += ShadingRule.moveUnder("bintry",   "uk.gov.hmrc.sbt-artifactory.shaded"),
+    shadingRules += ShadingRule.moveUnder("bintray",  "uk.gov.hmrc.sbt-artifactory.shaded"),
+    validNamespaces += "uk",
+    validNamespaces += "sbt", // sbt/sbt.autoplugins needs to be in route
+    validNamespaces += "org", // org.scalajs.sbtplugin.ScalaJSPlugin$AutoImport$ needs to be untouched
+
+    shadingVerbose := true,
   )

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,10 +1,7 @@
-resolvers += Resolver.url("hmrc-sbt-plugin-releases", url("https://dl.bintray.com/hmrc/sbt-plugin-releases"))(
-  Resolver.ivyStylePatterns)
-
+resolvers += Resolver.bintrayIvyRepo("hmrc", "sbt-plugin-releases")
 resolvers += Resolver.bintrayRepo("hmrc", "releases")
 
-addSbtPlugin("uk.gov.hmrc" % "sbt-auto-build" % "2.9.0")
-
-addSbtPlugin("uk.gov.hmrc" % "sbt-git-versioning" % "2.1.0")
-
-addSbtPlugin("uk.gov.hmrc" % "sbt-artifactory" % "1.4.0")
+addSbtPlugin("uk.gov.hmrc"     % "sbt-auto-build"     % "2.9.0")
+addSbtPlugin("uk.gov.hmrc"     % "sbt-git-versioning" % "2.1.0")
+addSbtPlugin("uk.gov.hmrc"     % "sbt-artifactory"    % "1.6.0")
+addSbtPlugin("io.get-coursier" % "sbt-shading"        % "2.0.0")


### PR DESCRIPTION
When sbt-artifactory 1.3.0 was deployed locally and 1.7.0 as a global plugin, sbt could not load the plugins, since it seems to merge the dependencies of the two versions before applying evictions. 1.3.0 uses a later version of dispatch-core, than 1.7.0 and it loads 1.7.0 with the later version of dispatch-core. We would have expected 1.7.0 to evict 1.3.0, and then load it's dependencies, ignoring any dependencies of 1.3.0.
This seems to be a bug in sbt 1.3.x, and seems to have been fixed in 1.4.x.
To allow us to deploy sbt-artifactory as a global plugin, without any changes to services (which many have sbt-artifactory included in their builds still), we have opted to build a fat-jar, shading it's dependencies, where they will not be evicted by sbt.