### PR TITLE
BDOG-1187

### DIFF
--- a/src/main/scala/uk/gov/hmrc/SbtArtifactory.scala
+++ b/src/main/scala/uk/gov/hmrc/SbtArtifactory.scala
@@ -125,7 +125,10 @@ object SbtArtifactory extends sbt.AutoPlugin{
           streams.value.log.info("SbtArtifactoryPlugin - Nothing to unpublish from Bintray...")
         }
       }
-    }).result.value,// fail silently
+    }).result.value.toEither.left.foreach {
+      //don't propagate exception
+      incomplete => streams.value.log.info(s"SbtArtifactoryPlugin - Failed to unpublish from Bintray:\n $incomplete")
+    },
     unpublish := Def.sequential(
       unpublishFromArtifactory,
       unpublishFromBintray
@@ -142,7 +145,10 @@ object SbtArtifactory extends sbt.AutoPlugin{
           streams.value.log.info("SbtArtifactoryPlugin - Not publishing to Bintray...")
         }
       }
-    }).value,
+    }).result.value.toEither.left.foreach {
+      //don't propagate exception
+      incomplete => streams.value.log.info(s"SbtArtifactoryPlugin - Failed to publish to Bintray:\n $incomplete")
+    },
     publish := Def.sequential(
       publishToArtifactory,
       publishToBintray


### PR DESCRIPTION

Exception isn't very pretty - but doesn't seem to be an easy way to print a clean message

```
Incomplete(node=Some(Task(_)), tpe=Error, msg=None, causes=List(Incomplete(node=Some(Task(_)), tpe=Error, msg=None, causes=List(Incomplete(node=Some(Task(_)), tpe=Error, msg=None, causes=List(Incomplete(node=Some(Task((tags: Map(Tag(publish) -> 1, Tag(network) -> 1)))), tpe=Error, msg=None, causes=List(Incomplete(node=Some(Task(_)), tpe=Error, msg=None, causes=List(), directCause=Some(java.lang.RuntimeException: error uploading to https://api.bintray.com/maven/hmrc-digital1/releases-lab03/time/uk/gov/hmrc/time_2.12/3.11.0/time_2.12-3.11.0.pom: {"message":"This resource requires authentication"}))), directCause=None)), directCause=None)), directCause=None)), directCause=None)
```